### PR TITLE
arm_chainloader: fix core 0 detection for single-core machines

### DIFF
--- a/arm_chainloader/start.s
+++ b/arm_chainloader/start.s
@@ -43,9 +43,12 @@ _start:
 
 L_all_cores_start:
         /* check CPU id */
-        mrc p15, 0, r0, c0, c0, 5
-        ands r0, r0, #0x03
-        bne L_deadloop
+	mrc p15, 0, r0, c0, c0, 5	@ read MPIDR
+	and r3, r0, #0xc0000000		@ multiprocessing extensions and
+	teq r3, #0x80000000		@ not part of a uniprocessor system?
+	bne L_core0			@ no, assume UP
+	ands r0, r0, #0x03		@ CPU 0?
+	bne L_deadloop			@ if not, spin.
 
 L_core0:
 	mov sp, #0x2000000


### PR DESCRIPTION
For example, a Pi 1 seem to have a MPIDR value of 0x410fb767.
Add a check similar to Linux: test that bit 31 (multiprocessor
extensions) is set and bit 30 (uniprocessor system) is clear
before looking at the core number.

Signed-off-by: Alex Badea vamposdecampos@gmail.com
