### PR TITLE
arm linker script: align _end to 32-bit boundary

### DIFF
--- a/arm_chainloader/linker.lds
+++ b/arm_chainloader/linker.lds
@@ -35,5 +35,6 @@ SECTIONS
 		*(.bss)
 	}
 
+	. = ALIGN(32 / 8);
 	_end = . ;
 }


### PR DESCRIPTION
We initialize the memory allocator right after _end; but tlsf
requires that its start adress be pointer-size-aligned, and
chokes if it isn't:

[BRINGUP:heap_init]: Initializing heap at 0x929d with size 0x100000
init_memory_pool (): mem_pool must be aligned to a word

Fix that by rounding up the _end address in the linker script.

Signed-off-by: Alex Badea vamposdecampos@gmail.com
