### PR TITLE
loader: fix update of bootargs in FDT

### DIFF
--- a/arm_chainloader/loader.cc
+++ b/arm_chainloader/loader.cc
@@ -90,8 +90,16 @@ struct LoaderImpl {
 			panic("fdt blob invalid, fdt_check_header returned %d", res);
 		}
 
-                /* pass in command line args */
-                fdt_setprop(v_fdt, 0, "chosen/cmdline", cmdline, strlen((char*) cmdline));
+		/* pass in command line args */
+		res = fdt_open_into(v_fdt, v_fdt, sz + 4096);
+		logf("fdt_open_into(): %d\n", res);
+
+		int node = fdt_path_offset(v_fdt, "/chosen");
+		logf("/chosen node: %d\n", node);
+		if (node < 0)
+			return NULL;
+		res = fdt_setprop(v_fdt, node, "bootargs", cmdline, strlen((char*) cmdline) + 1);
+		logf("fdt_setprop(): %d\n", res);
 
 		logf("valid fdt loaded at 0x%X\n", (unsigned int)fdt);
 


### PR DESCRIPTION
The prop name used by the kernel is "bootargs", instead of "cmdline".
fdt_setprop() doesn't follow paths, so we need to find the node first.
Also appeding/extending a property requires storage, and libfdt refuses
to do that unless you explicitly tell it you reserved some space.  Since
we load the FDT at the start of unused RAM, we simply grab another 4K
afterwards.

Signed-off-by: Alex Badea vamposdecampos@gmail.com
