### PR TITLE
Don't override CROSS_COMPILE if it's already set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ default: $(TARGET_BOOTCODE)
 OBJ := $(addprefix $(TARGET_BUILD_DIR)/, $(addsuffix .o, $(basename $(SRCS))))
 
 # the cross compiler should already be in your path
-CROSS_COMPILE = vc4-elf-
+CROSS_COMPILE ?= vc4-elf-
 CC = $(CROSS_COMPILE)gcc
 CXX = $(CROSS_COMPILE)g++
 AS = $(CC)

--- a/arm_chainloader/Makefile
+++ b/arm_chainloader/Makefile
@@ -46,7 +46,7 @@ default: $(TARGET_ARM_CHAINLOADER)
 
 OBJ := $(addprefix $(TARGET_BUILD_DIR)/, $(addsuffix .o, $(basename $(SRCS))))
 
-CROSS_COMPILE = arm-none-eabi-
+CROSS_COMPILE ?= arm-none-eabi-
 CC = $(CROSS_COMPILE)gcc
 CXX = $(CROSS_COMPILE)gcc
 AS = $(CC)


### PR DESCRIPTION
This will allow to set CROSS_COMPILE from the ENV.